### PR TITLE
Fixed windows issue & updated typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "build": "npm run assets && webpack -p",
     "open:dev": "opener http://localhost:8080/webpack-dev-server/",
     "serve": "webpack-dev-server",
-    "start": "parallelshell 'npm run serve' 'npm run open:dev'",
+    "start": "parallelshell \"npm run serve\" \"npm run open:dev\"",
     "deploy": "npm run build && node deploy.js"
   },
   "author": "Geoffroy Warin",
   "license": "MIT",
   "devDependencies": {
-    "awesome-typescript-loader": "^0.3.0-rc.4",
+    "awesome-typescript-loader": "^0.15.10",
     "css-loader": "^0.12.0",
     "extract-text-webpack-plugin": "^0.7.1",
     "gh-pages": "^0.2.0",
@@ -28,6 +28,7 @@
     "rimraf": "^2.3.3",
     "script-loader": "^0.6.1",
     "style-loader": "^0.12.2",
+    "typescript": "^1.7.5",
     "webpack": "^1.8.11",
     "webpack-dev-server": "^1.8.2"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,9 @@
         "./app/src/state/Preload.ts",
         "./app/src/state/States.ts"
     ],
+    "exclude": [
+        "node_modules",
+        "bower_components"
+    ],
     "compileOnSave": false
 }


### PR DESCRIPTION
I couldn't run this repository on windows and decided to fix the issue.

Turns out, the typescript compiler was severely outdated, but the main issue was that window's cmd doesn't know what to do with single quotes
